### PR TITLE
Fix methods for custom-elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8551,9 +8551,9 @@
 			"dev": true
 		},
 		"typescript-3.6": {
-			"version": "npm:typescript@3.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+			"version": "npm:typescript@3.6.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
+			"integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
 			"dev": true
 		},
 		"typescript-3.7": {
@@ -8563,9 +8563,9 @@
 			"dev": true
 		},
 		"typescript-3.8": {
-			"version": "npm:typescript@3.8.0-dev.20200117",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200117.tgz",
-			"integrity": "sha512-80flPGfPkB9agERB/XHIt1C9F27EYBt3alVUS8VVjblPvigLjQbva/tkAhGacsbrRYzL8qWIEwRVTOrtiT2CaQ==",
+			"version": "npm:typescript@3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"ua-parser-js": {

--- a/src/analyze/analyzer-visit-context.ts
+++ b/src/analyze/analyzer-visit-context.ts
@@ -17,4 +17,5 @@ export interface AnalyzerVisitContext {
 		featureCollection: WeakMap<Node, ComponentFeatureCollection>;
 		general: Map<unknown, unknown>;
 	};
+	skipResolved: boolean;
 }

--- a/src/analyze/make-context-from-config.ts
+++ b/src/analyze/make-context-from-config.ts
@@ -33,6 +33,7 @@ export function makeContextFromConfig(options: AnalyzerOptions): AnalyzerVisitCo
 			analyzeLib: options.config?.analyzeLib ?? false,
 			excludedDeclarationNames: options.config?.excludedDeclarationNames ?? [],
 			features: options.config?.features ?? ALL_COMPONENT_FEATURES
-		}
+		},
+		skipResolved: options.skipResolved ? options.skipResolved : false
 	};
 }

--- a/src/analyze/stages/analyze-declaration.ts
+++ b/src/analyze/stages/analyze-declaration.ts
@@ -26,7 +26,7 @@ export function analyzeComponentDeclaration(initialDeclarationNodes: Node[], con
 	const inheritanceTree = discoverInheritance(initialDeclarationNodes, context);
 
 	// Find unique resolved nodes in the inheritance tree
-	const declarationNodes = getUniqueResolvedNodeForInheritanceTree(inheritanceTree);
+	const declarationNodes = getUniqueResolvedNodeForInheritanceTree(inheritanceTree, context.skipResolved);
 
 	// Add initial declaration nodes to the set (nodes that aren't the main declaration node)
 	for (const node of initialDeclarationNodes) {

--- a/src/analyze/types/analyzer-options.ts
+++ b/src/analyze/types/analyzer-options.ts
@@ -12,4 +12,5 @@ export interface AnalyzerOptions {
 	flavors?: AnalyzerFlavor[];
 	config?: AnalyzerConfig;
 	verbose?: boolean;
+	skipResolved?: boolean;
 }

--- a/src/cli/analyze/analyze-cli-command.ts
+++ b/src/cli/analyze/analyze-cli-command.ts
@@ -102,7 +102,8 @@ function transformResults(results: AnalyzerResult[] | AnalyzerResult, program: P
 		inlineTypes: config.inlineTypes ?? false,
 		visibility: config.visibility ?? "public",
 		markdown: config.markdown,
-		cwd: config.cwd
+		cwd: config.cwd,
+		skipResolved: config.skipResolved ?? false
 	};
 
 	return transformAnalyzerResult(format, results, program, transformerConfig);

--- a/src/cli/analyzer-cli-config.ts
+++ b/src/cli/analyzer-cli-config.ts
@@ -19,6 +19,7 @@ export interface AnalyzerCliConfig {
 	features?: ComponentFeature[];
 	discoverLibraryFiles?: boolean;
 	analyzeGlobalFeatures?: boolean;
+	skipResolved?: boolean;
 
 	markdown?: {
 		headerLevel?: number;

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -84,6 +84,10 @@ o {tagname}: The element's tag name`,
 			boolean: true,
 			hidden: true
 		})
+		.option("skipResolved", {
+			boolean: true,
+			hidden: true
+		})
 
 		// This options makes it possible to use "markdown.<sub-option>" in "strict mode"
 		.option("markdown", {

--- a/src/cli/util/analyze-globs.ts
+++ b/src/cli/util/analyze-globs.ts
@@ -68,7 +68,8 @@ export async function analyzeGlobs(
 			config: {
 				features: config.features,
 				analyzeGlobalFeatures: config.analyzeGlobalFeatures
-			}
+			},
+			skipResolved: config.skipResolved
 		});
 
 		logVerbose(() => stripTypescriptValues(result, program.getTypeChecker()), config);

--- a/src/transformers/json/custom-elements-json-data.ts
+++ b/src/transformers/json/custom-elements-json-data.ts
@@ -46,6 +46,7 @@ export interface HtmlDataTag {
 	name: string;
 	description?: string;
 	attributes?: HtmlDataAttribute[];
+	methods?: HtmlDataAttribute[];
 	path?: string;
 
 	// Suggested fields:

--- a/src/transformers/json/json-transformer.ts
+++ b/src/transformers/json/json-transformer.ts
@@ -5,6 +5,7 @@ import { ComponentDefinition } from "../../analyze/types/component-definition";
 import { ComponentCssPart } from "../../analyze/types/features/component-css-part";
 import { ComponentCssProperty } from "../../analyze/types/features/component-css-property";
 import { ComponentEvent } from "../../analyze/types/features/component-event";
+import { ComponentMethod } from "../../analyze/types/features/component-method";
 import { ComponentMember } from "../../analyze/types/features/component-member";
 import { ComponentSlot } from "../../analyze/types/features/component-slot";
 import { JsDoc } from "../../analyze/types/js-doc";
@@ -64,6 +65,10 @@ function definitionToHtmlDataTag(definition: ComponentDefinition, checker: TypeC
 		filterVisibility(config.visibility, declaration.members).map(d => componentMemberToHtmlDataProperty(d, checker, config))
 	);
 
+	const methods = arrayDefined(
+		filterVisibility(config.visibility, declaration.methods).map(d => componentMethodToHtmlDataAttribute(d, checker, config))
+	);
+
 	const events = arrayDefined(filterVisibility(config.visibility, declaration.events).map(e => componentEventToHtmlDataEvent(e, checker)));
 
 	const slots = arrayDefined(declaration.slots.map(e => componentSlotToHtmlDataSlot(e, checker)));
@@ -78,6 +83,7 @@ function definitionToHtmlDataTag(definition: ComponentDefinition, checker: TypeC
 		description: getDescriptionFromJsDoc(declaration.jsDoc),
 		attributes: attributes.length === 0 ? undefined : attributes,
 		properties: properties.length === 0 ? undefined : properties,
+		methods: methods.length === 0 ? undefined : methods,
 		events: events.length === 0 ? undefined : events,
 		slots: slots.length === 0 ? undefined : slots,
 		cssProperties: cssProperties.length === 0 ? undefined : cssProperties,
@@ -147,6 +153,18 @@ function componentMemberToHtmlDataProperty(member: ComponentMember, checker: Typ
 		default: member.default != null ? JSON.stringify(member.default) : undefined,
 		deprecated: member.deprecated === true || undefined,
 		deprecatedMessage: typeof member.deprecated === "string" ? member.deprecated : undefined
+	};
+}
+
+function componentMethodToHtmlDataAttribute(member: ComponentMethod, checker: TypeChecker, config: TransformerConfig): HtmlDataAttribute | undefined {
+	if (member.name == null) {
+		return undefined;
+	}
+
+	return {
+		name: member.name,
+		description: getDescriptionFromJsDoc(member.jsDoc),
+		type: getTypeHintFromType(member.type?.(), checker, config)
 	};
 }
 

--- a/src/transformers/transformer-config.ts
+++ b/src/transformers/transformer-config.ts
@@ -8,4 +8,5 @@ export interface TransformerConfig {
 		headerLevel?: number;
 	};
 	inlineTypes?: boolean;
+	skipResolved?: boolean;
 }


### PR DESCRIPTION
Show methods for custom-elements (polymer classes)
Add cli option to skip resolved tree
The inheritance tree now skips methods from the resolved nodes

Testing Done -
 `npm run test` and `npm run test/all` to verify that there are no breaking changes.

Tested and found that the methods sections is added to custom-elements.json
and deep inherited methods are neglected.